### PR TITLE
Acronym explained. We look beyond UK

### DIFF
--- a/mission.md
+++ b/mission.md
@@ -1,10 +1,10 @@
 # Mission Statement
 
-The UK Hackspace Foundation exists to support and further the goals of the [](Hackspace movement) across the UK. We are a not-for-profit democratic organisation that links the spaces together, allowing geographically distributed Hackspace groups to share knowledge, resources, and collectively plan for the future.
+The UK Hackspace Foundation (UK-HSF) exists to support and further the goals of the [](Hackspace movement) across the UK. We are a not-for-profit democratic organisation that links the spaces together, allowing geographically distributed Hackspace groups to share knowledge, resources, and collectively plan for the future.
 
 The Foundation presents a unified front that enables us to communicate and negotiate with organisations for the benefit of our member spaces, while also ensuring that approaches from external organisations are directed to the most appropriate space. We present a single point of contact for the Hackspaces across the UK and perform outreach on behalf of the entire movement, attempting to raise public awareness and interest in their local spaces.
 
-We aim to make setting up Hackspaces simpler, less daunting, and actively work to foster their development in locations we know are underserved. Member spaces have representatives who can privately seek advice from other spaces across the UK, and the HSF can introduce them to friendly specialist contacts such as lawyers and accountants where nessecary. The Foundation carries out research across the UK spaces in order to spot patterns and provide advice based on the collective experience of the member spaces.
+We aim to make setting up Hackspaces simpler, less daunting, and actively work to foster their development in locations we know are underserved. Member spaces have representatives who can privately seek advice from other spaces across the UK, and the UK-HSF can introduce them to friendly specialist contacts such as lawyers and accountants where nessecary. The Foundation carries out research across the UK spaces and beyond in order to spot patterns and provide advice based on the collective experience of the member spaces.
 
 While the Foundation exists primarily for the benefit of spaces meeting the Hackspace Definition, we maintain active links with other groups, communities, and companies. We believe that Hackspaces are part of a larger movement encompassing many other types of organisation, and that all are equally important to our growing culture.
 


### PR DESCRIPTION
the HSF acronym is used mid text. I changed to UK-HSF. We also strive to get info from other HS around the globe. Examples include electronic access to spaces and other Free software projects.